### PR TITLE
Add a MariaDB example that runs as non-root and inits itself

### DIFF
--- a/fedora-mariadb/Dockerfile
+++ b/fedora-mariadb/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora:20
+MAINTAINER Clayton Coleman <ccoleman@redhat.com>
+
+RUN yum install -y mariadb mariadb-server && yum clean all
+
+RUN mkdir -p /var/log/mysql && \
+    chown mysql:mysql /var/log/mysql /var/lib/mysql && \
+    touch /var/log/mysql/.keep /var/lib/mysql/.keep
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
+
+USER mysql
+ADD ./simple.cnf /etc/my.cnf.d/
+ADD ./start /usr/bin/run
+
+EXPOSE 3306
+CMD ["/usr/bin/run"]

--- a/fedora-mariadb/simple.cnf
+++ b/fedora-mariadb/simple.cnf
@@ -1,0 +1,152 @@
+# Simple MariaDB database server configuration file.
+#
+# =================================================================
+# Base configuration courtesy of Open Query (http://openquery.com/)
+# For production use, case-specific preparation is still required.
+# 2009-10-07
+#
+# This is *not* an optimised config, merely a more sane baseline:
+# - binary and slow log enabled, with enhancements
+# - InnoDB default (e.g., ACID out-of-the-box, same as on Windows)
+# - strict mode (for proper input checks, same as on Windows)
+# - various other useful settings
+# - make use of MariaDB/Percona/OurDelta enhancements/extensions
+#
+# For tuning assistance, please see http://openquery.com/services
+# =================================================================
+
+[client]
+default-character-set  = utf8
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+nice		= 0
+log-error=/var/log/mysql/mysqld.log
+
+[server]
+#
+# * Basic Settings
+#
+user		= mysql
+tmpdir		= /tmp
+skip-external-locking
+
+#
+# * Fine Tuning
+#
+max_connections		= 32
+connect_timeout		= 5
+wait_timeout		= 600
+max_allowed_packet	= 16M
+thread_cache_size       = 128
+sort_buffer_size	= 4M
+bulk_insert_buffer_size	= 16M
+tmp_table_size		= 32M
+max_heap_table_size	= 32M
+#
+# * MyISAM
+#
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched. On error, make copy and try a repair.
+myisam_recover          = BACKUP
+key_buffer_size		= 128M
+#open-files-limit	= 2000
+table_cache             = 400
+myisam_sort_buffer_size	= 512M
+concurrent_insert	= 2
+read_buffer_size	= 2M
+read_rnd_buffer_size	= 1M
+#
+# * Query Cache Configuration
+#
+# Cache only tiny result sets, so we can fit more in the query cache.
+query_cache_limit		= 128K
+query_cache_size		= 64M
+# for more write intensive setups, set to DEMAND or OFF
+#query_cache_type		= DEMAND
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
+#
+# we do want to know about network errors and such
+log_warnings		= 2
+#
+# Here you can see queries with especially long duration
+slow_query_log
+slow_query_log_file		= /var/log/mysql/mariadb-slow.log
+long_query_time = 10
+#log_slow_rate_limit	= 1000
+log_slow_verbosity	= query_plan
+
+#log-queries-not-using-indexes
+log_slow_admin_statements
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#report_host		= master1
+#auto_increment_increment = 2
+#auto_increment_offset	= 1
+log_bin			= /var/log/mysql/mariadb-bin
+log_bin_index		= /var/log/mysql/mariadb-bin.index
+# not fab for performance, but safer
+#sync_binlog		= 1
+expire_logs_days	= 10
+max_binlog_size         = 100M
+# slaves
+#relay_log		= /var/log/mysql/relay-bin
+#relay_log_index	= /var/log/mysql/relay-bin.index
+#relay_log_info_file	= /var/log/mysql/relay-bin.info
+#log_slave_updates
+#read_only
+#
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+default_storage_engine	= InnoDB
+sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+# you can't just change log file size, requires special procedure
+innodb_log_file_size	= 16M
+innodb_buffer_pool_size	= 265M
+innodb_log_buffer_size	= 8M
+innodb_file_per_table	= 1
+innodb_open_files	= 400
+innodb_io_capacity	= 400
+innodb_flush_method	= O_DIRECT
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completition
+
+[isamchk]
+key_buffer		= 16M

--- a/fedora-mariadb/start
+++ b/fedora-mariadb/start
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+ln -s /dev/stderr /var/log/mysql/mysqld.log
+if [ ! -f /var/lib/mysql/.created ]; then
+  function wait_for_mysqld_start {
+    for i in {1..30}; do
+      if echo 'select 1' | mysql -u root > /dev/null 2>&1; then
+        return 0
+      fi
+      sleep 1
+    done
+
+    echo "MariaDB did not start in time"
+    exit 1
+  }
+
+  password=${DB_PASSWORD:-password}
+  dbname=${DB_NAME:-master}
+
+  /usr/bin/mysql_install_db -u mysql
+
+  /usr/libexec/mysqld &
+  pid=$!
+
+  wait_for_mysqld_start
+
+  echo "Creating database $dbname ..."
+
+  sql=$(cat <<SQL
+  drop database if exists test;
+  create database \`$dbname\`
+     DEFAULT CHARACTER SET utf8 DEFAULT
+     COLLATE utf8_general_ci;
+SQL
+)
+  echo $sql | mysql -u root
+
+  #delete from user;
+
+  sql=$(cat <<SQL
+    delete from user where user='';
+    grant all on *.* to 'mysql'@'localhost' identified by '$password' with grant option;
+    grant all on *.* to 'mysql'@'%' identified by '$password' with grant option;
+    flush privileges;
+SQL
+)
+  echo $sql | mysql -u root mysql
+
+  touch /var/lib/mysql/.created
+  kill -TERM $pid
+
+  echo "Starting mysqld ..."
+fi
+
+exec /usr/libexec/mysqld


### PR DESCRIPTION
Built as index.docker.io/u/ccoleman/fedora-mariadb
