### PR TITLE
Add a fedora redis server example.

### DIFF
--- a/fedora-redis/Dockerfile
+++ b/fedora-redis/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora
+MAINTAINER Mrunal Patel <mpatel@redhat.com>
+
+RUN yum install redis -y && yum clean all
+
+RUN mkdir -p /var/lib/redis && \
+    chown redis.redis /var/lib/redis && \
+    touch /var/lib/redis/.keep
+
+VOLUME ["/var/lib/redis"]
+
+EXPOSE 6379
+
+USER redis
+
+CMD  ["/usr/sbin/redis-server"]


### PR DESCRIPTION
Dockerfile for redis server on Fedora.
