### PR TITLE
Provide two images for Ruby (centos-ruby and centos-ruby-extended) instead of tags

### DIFF
--- a/centos-ruby/base/Dockerfile
+++ b/centos-ruby/base/Dockerfile
@@ -1,8 +1,13 @@
-# This is a base 'centos-ruby' image which provides basic
-# support for ruby193 applications
+# centos-ruby
+#
+# This image provide a base for running Ruby based applications. It provides
+# just base Ruby installation using SCL and Ruby application server.
+#
+# If you want to use Bundler with C-extensioned gems or MySQL/PostGresql, you
+# can use 'centos-ruby-extended' image instead.
 #
 
-FROM       centos:latest
+FROM       centos
 MAINTAINER Michal Fojtik <mfojtik@redhat.com>
 
 # Pull in important updates and then install ruby193 SCL

--- a/centos-ruby/extended/Dockerfile
+++ b/centos-ruby/extended/Dockerfile
@@ -1,10 +1,10 @@
-# centos-ruby:extended
+# centos-ruby-extended
 #
-# Extended 'centos-ruby' image which allows developers to compile
-# C extensioned rubygems and provide header files.
+# This image provide additional resource for Ruby developers such as additional
+# development files and libraries.
 #
 
-FROM mfojtik/centos-ruby:base
+FROM openshift/centos-ruby
 MAINTAINER Michal Fojtik <mfojtik@redhat.com>
 
 RUN yum install --assumeyes gcc automake autoconf curl-devel openssl-devel \


### PR DESCRIPTION
This patch replace usage of Docker image tags (:base, :extended) for centos-ruby with two separate images (centos-ruby and centos-ruby-extended).
