### PR TITLE
Add 'exec' to ruby_context script in centos-ruby base image

### DIFF
--- a/centos-ruby/base/bin/ruby_context
+++ b/centos-ruby/base/bin/ruby_context
@@ -12,13 +12,9 @@ export GEM_INSTALL_OPTS="--bindir ${RUBY_BIN_DIR}"
 # assets to compile successfully
 #
 
-scl_cmd="/usr/bin/scl enable ruby193"
-
-if is_nodejs_installed; then
-  scl_cmd="$scl_cmd nodejs010"
-fi
+collections="ruby193 $(is_nodejs_installed && echo 'nodejs010')"
 
 # You can reference environment variables in Dockerfile RUN
 # command and they will be substituted here
 #
-$scl_cmd "$(echo -n "$@" | envsubst)"
+exec /usr/bin/scl enable ${collections} "$(echo -n "$@" | envsubst)"

--- a/centos-ruby/base/etc/sdk
+++ b/centos-ruby/base/etc/sdk
@@ -14,3 +14,7 @@ function restore_build_artifacts() {
     popd >/dev/null
   fi
 }
+
+function dir_not_empty() {
+  [ -n "$(ls -A "$1" 2>/dev/null)" ]
+}


### PR DESCRIPTION
This will also sneak in 'dir_not_empty' helper we use in self-contained builder scenario.
