### PR TITLE
Initial implementation of incremental build in self-contained ruby builder image

### DIFF
--- a/centos-ruby-builder/bin/restore-artifacts
+++ b/centos-ruby-builder/bin/restore-artifacts
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-tar -C / -xf -
+cd $HOME
+
+exec tar -xzf -

--- a/centos-ruby-builder/bin/restore-artifacts
+++ b/centos-ruby-builder/bin/restore-artifacts
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tar -C / -xf -

--- a/centos-ruby-builder/bin/save-artifacts
+++ b/centos-ruby-builder/bin/save-artifacts
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tar -cf - /opt/ruby/bundle

--- a/centos-ruby-builder/bin/save-artifacts
+++ b/centos-ruby-builder/bin/save-artifacts
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-tar -cf - /opt/ruby/bundle
+cd $HOME
+
+# List the files and directories you would like to archive.
+#
+exec tar -czf - {bundle,gems}

--- a/centos-ruby-builder/bin/start
+++ b/centos-ruby-builder/bin/start
@@ -11,6 +11,13 @@ source ${HOME}/etc/helpers
 # If the /tmp/src is empty, then print usage and exit.
 (dir_is_empty /tmp/src) && print_usage_and_exit
 
+# Detect presence of $stdin and restore the artifacts
+#
+if [ -p /dev/stdin ]; then
+  echo "---> Restoring artifacts from STDIN"
+  cat | /opt/ruby/bin/restore-artifacts
+fi
+
 # Build the ruby application first
 #
 ${HOME}/bin/prepare

--- a/centos-ruby-builder/bin/start
+++ b/centos-ruby-builder/bin/start
@@ -11,11 +11,14 @@ source ${HOME}/etc/helpers
 # If the /tmp/src is empty, then print usage and exit.
 (dir_is_empty /tmp/src) && print_usage_and_exit
 
-# Detect presence of $stdin and restore the artifacts
+# Detect the presence of $stdin and restore the artifacts
+# To restore the artifacts, you have to run the builder as:
+#
+# docker run -v $(pwd):/tmp/src openshift/centos-ruby-builder < artifacts.tgz
 #
 if [ -p /dev/stdin ]; then
-  echo "---> Restoring artifacts from STDIN"
-  cat | /opt/ruby/bin/restore-artifacts
+  echo "---> Restoring artifacts"
+  cat | ${HOME}/bin/restore-artifacts
 fi
 
 # Build the ruby application first
@@ -24,5 +27,6 @@ ${HOME}/bin/prepare
 
 # Replace this script with the application runner at the end of the build.
 #
-echo "---> Build successful. Commit this image with: docker commit ${HOSTNAME} ruby-app"
+echo "---> Build successful. Commit this image with: 'docker commit ${HOSTNAME} ruby-app'"
+
 cp -f ${HOME}/bin/run ${HOME}/bin/start && exit

--- a/centos-ruby-builder/etc/helpers
+++ b/centos-ruby-builder/etc/helpers
@@ -3,14 +3,22 @@
 
 function print_usage_and_exit() {
   echo
-  echo "This image can build your Ruby source code."
-  echo "To build from a git repo, run this in your checked out repo:"
+  echo "This is the Ruby/Rails self-contained builder image."
+  echo "You can use this to produce application images:"
   echo
-  echo "  docker run -v \$(pwd):/tmp/src openshift/centos-ruby-builder"
+  echo "  $ docker run -v \$(pwd):/tmp/src openshift/centos-ruby-builder"
   echo
-  echo "Options:"
+  echo "You can also archive artifacts from the current application image:"
+  echo
+  echo "  $ docker run --entrypoint='${HOME}/bin/save-artifacts' ruby-app > archive.tgz"
+  echo
+  echo "And restore the artifacts on the next build:"
+  echo
+  echo "  $ docker run -v \$(pwd):/tmp/src openshift/centos-ruby-builder < archive.tgz"
+  echo
+  echo "Other options:"
   echo
   echo "  --debug       Drop to the shell instead of build."
   echo
-  exit
+  exit 0
 }


### PR DESCRIPTION
This is a demo of incremental build using plain Docker. 

I like this because:
1. It is super simple :-)
2. You don't need any local storage for artifacts (could be streamed from the app image to builder using UNIX pipe)
3. You don't need to store artifacts inside container/image
4. You don't need to volume mount and fight with permissions
5. No whitelist required, just specify the files/dirs you want to archive `save-artifacts` command.

I don't like this because:
1. The command line is a bit complex for the daily use (however, STI can make it user friendly ;-)
2. Streaming from one container to another is currently a bit wonky ;-)

So, the basic workflow is following:

**First do the 'clean' build**

```
$ git clone https://github.com/mfojtik/sinatra-app-example && cd sinatra-app-example
$ docker run --cidfile="cid" -v $(pwd):/tmp/src openshift/centos-ruby-builder
---> Installing application source
---> Building your Ruby application from source
---> Installing dependencies using Bundler
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/..
Installing rack (1.5.2) 
Installing puma (2.8.1) with native extensions 
Installing rack-protection (1.5.2) 
Installing tilt (1.4.1) 
Installing sinatra (1.4.4) 
Using bundler (1.1.4) 
Your bundle is complete! It was installed into /opt/ruby/bundle
---> Build successful. Commit this image with: docker commit be13bb030ef0 ruby-app
$ docker commit $(cat cid) ruby-app && rm -f cid
```

**Then save artifacts**

```
$ docker run --rm --entrypoint="/opt/ruby/bin/save-artifacts" ruby-app > artifacts.tar
```

**Then do a Incremental build**

```
$ docker run  -v $(pwd):/tmp/src -i openshift/centos-ruby-builder < artifacts.tar
---> Restoring artifacts from STDIN
---> Installing application source
---> Building your Ruby application from source
---> Installing dependencies using Bundler
Using rack (1.5.2) 
Using puma (2.8.1) 
Using rack-protection (1.5.2) 
Using tilt (1.4.1) 
Using sinatra (1.4.4) 
Using bundler (1.1.4) 
Your bundle is complete! It was installed into /opt/ruby/bundle
---> Build successful. Commit this image with: docker commit d6a664fb4058 ruby-app
```

Alternatively, we can execute this in one long shot:
(currently not working, I have some streaming issues from 'save-artifacts' which keeps the stdout open... but this is fixable)

```
$ docker run --rm --entrypoint="/opt/ruby/bin/save-artifacts" ruby-app | docker run --cidfile="cid" -v $(pwd):/tmp/src -i openshift/centos-ruby-builder
```
