### PR TITLE
Allow users of self-contained builder to provide alternate location for assemble scripts

### DIFF
--- a/centos-ruby-builder/bin/restore-artifacts
+++ b/centos-ruby-builder/bin/restore-artifacts
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd $HOME
-
-exec tar -xzf -
+# Reads the archive with artifacts from STDIN and extract it
+# into the $HOME (/opt/ruby) folder.
+#
+# NOTE: Docker needs to be run with --interactive (-i) option to route
+#       the stdin properly.
+#
+cd $HOME && exec tar -xzf -

--- a/centos-ruby-builder/bin/save-artifacts
+++ b/centos-ruby-builder/bin/save-artifacts
@@ -1,7 +1,9 @@
 #!/bin/bash
-
-cd $HOME
-
+#
+# Create the archive with files/folders you would like to
+# preserve for the next build. Then the archive is streamed into
+# STDOUT.
+#
 # List the files and directories you would like to archive.
 #
-exec tar -czf - {bundle,gems}
+cd $HOME && exec tar -czf - {bundle,gems}

--- a/centos-ruby-builder/bin/start
+++ b/centos-ruby-builder/bin/start
@@ -3,10 +3,19 @@
 source ${HOME}/etc/sdk
 source ${HOME}/etc/helpers
 
-# Allow users to inspect/debug the builder image itself, by using:
-# $ docker run -i -t openshift/centos-ruby-builder --debug
-#
-[ "$1" == "--debug" ] && exec /bin/bash
+while getopts “ht:r:p:v” opt; do
+  case $opt in
+    h)
+      print_usage_and_exit
+      ;;
+    s)
+      download_assemble_scripts "${OPTARG}"
+      ;;
+    d)
+      exec /bin/bash
+      ;;
+  esac
+done
 
 # If the /tmp/src is empty, then print usage and exit.
 (dir_is_empty /tmp/src) && print_usage_and_exit

--- a/centos-ruby-builder/bin/start
+++ b/centos-ruby-builder/bin/start
@@ -3,7 +3,15 @@
 source ${HOME}/etc/sdk
 source ${HOME}/etc/helpers
 
-while getopts “ht:r:p:v” opt; do
+# If the /tmp/src is empty, then print usage and exit.
+(dir_is_empty /tmp/src) && print_usage_and_exit
+
+# If the directory with sources contain '.sti' folder, then look for the
+# prepare/run/etc. scripts there and replace the 'base' image scripts.
+#
+(! dir_is_empty /tmp/src/.sti ) && copy_assemble_scripts
+
+while getopts “h:s:d” opt; do
   case $opt in
     h)
       print_usage_and_exit
@@ -17,9 +25,6 @@ while getopts “ht:r:p:v” opt; do
   esac
 done
 
-# If the /tmp/src is empty, then print usage and exit.
-(dir_is_empty /tmp/src) && print_usage_and_exit
-
 # Detect the presence of $stdin and restore the artifacts
 # To restore the artifacts, you have to run the builder as:
 #
@@ -30,12 +35,18 @@ if [ -p /dev/stdin ]; then
   cat | ${HOME}/bin/restore-artifacts
 fi
 
-# Build the ruby application first
+# Prepare the Ruby application source code which includes:
+#
+# * (optional) Restore artifacts (bundle/vendor) from the previous build
+# * Installing all rubygems dependencies using Bundler
+# * (optional) Complilation of the Rails assets (rake assets:precompile)
 #
 ${HOME}/bin/prepare
 
-# Replace this script with the application runner at the end of the build.
-#
 echo "---> Build successful. Commit this image with: 'docker commit ${HOSTNAME} ruby-app'"
 
+# Once the Ruby application sources are prepared, replace
+# this script with the 'run' script that launch the application
+# using Ruby application server (puma or rackup by default).
+#
 cp -f ${HOME}/bin/run ${HOME}/bin/start && exit

--- a/centos-ruby-builder/contrib/perf-test.sh
+++ b/centos-ruby-builder/contrib/perf-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+mkdir $(pwd)/.test
+
+test_app_name="test-app-$(date +%s)"
+
+git clone https://github.com/mfojtik/sinatra-app-example .test/app
+cd .test/app
+
+function run_clean_build() {
+  docker run --cidfile="app.cid" -v $(pwd):/tmp/src openshift/centos-ruby-builder
+  docker commit $(cat app.cid) $test_app_name
+  rm -f app.cid
+}
+
+function run_inc_build() {
+  docker run --rm --entrypoint="/opt/ruby/bin/save-artifacts" $test_app_name > ../archive.tgz
+  docker run --cidfile="app.cid" -i -v $(pwd):/tmp/src openshift/centos-ruby-builder < ../archive.tgz
+  docker commit $(cat app.cid) $test_app_name
+  rm -f app.cid
+}
+
+time run_clean_build
+echo "gem 'nokogiri'" >> Gemfile
+bundle install
+time run_inc_build
+echo "gem 'therubyracer'" >> Gemfile
+bundle install
+time run_inc_build
+echo "gem 'rails'" >> Gemfile
+bundle install
+time run_inc_build
+
+cd ../.. && rm -rf .test

--- a/centos-ruby-builder/etc/helpers
+++ b/centos-ruby-builder/etc/helpers
@@ -25,6 +25,12 @@ function print_usage_and_exit() {
   exit 0
 }
 
+# Functions to support downloading/replacing the base image scripts.
+# Users could override them by:
+#
+# 1) Adding them into GIT_SOURCE/.sti/ folder
+# 1) Using '-s URL' on the builder command line
+
 function download_script() {
   local url="$1"
   local script_name="$2"
@@ -33,10 +39,24 @@ function download_script() {
   fi
 }
 
+function copy_script() {
+  local $script_name="$1"
+  [ ! -f "/tmp/src/.sti/${script_name}"] && return
+  cp -f "/tmp/src/.sti/${script_name}" "${HOME}/bin/${script_name}" && \
+    chmod +x "${HOME}/bin/${script_name}"
+}
+
 function download_assemble_scripts() {
   # FIXME: Rename 'prepare' to 'assemble' at some point.
   download_script "$1" "prepare"
   download_script "$1" "save-artifacts"
   download_script "$1" "restore-artifacts"
   download_script "$1" "run"
+}
+
+function copy_assemble_scripts() {
+  copy_script 'prepare'
+  copy_script 'save-artifacts'
+  copy_script 'restore-artifacts'
+  copy_script 'run'
 }

--- a/centos-ruby-builder/etc/helpers
+++ b/centos-ruby-builder/etc/helpers
@@ -18,7 +18,25 @@ function print_usage_and_exit() {
   echo
   echo "Other options:"
   echo
-  echo "  --debug       Drop to the shell instead of build."
+  echo "  -s <URL>  Point builder to remote directory with assemble scripts"
+  echo "  -h        Print this usage"
+  echo "  -d        Drop to the shell instead of build."
   echo
   exit 0
+}
+
+function download_script() {
+  local url="$1"
+  local script_name="$2"
+  if ! curl --silent -L "${url}/${script_name}" > ${HOME}/bin/${script_name}; then
+    echo "Warning: Unable to download '${url}/${script_name}' ($?)"
+  fi
+}
+
+function download_assemble_scripts() {
+  # FIXME: Rename 'prepare' to 'assemble' at some point.
+  download_script "$1" "prepare"
+  download_script "$1" "save-artifacts"
+  download_script "$1" "restore-artifacts"
+  download_script "$1" "run"
 }


### PR DESCRIPTION
This is following the logic @bparees used for https://github.com/bparees/docker-image-examples/tree/remote_scripts/centos-wildfly-noscript

You can overide the default builder scripts by adding `-s URL` argument to the builder. In that case, builder image will fetch `prepare,run,save-artifacts` and `restore-artifacts` scripts from a remote HTTP directory and replace the original scripts.

```
$ docker run -v $(pwd):/tmp/src openshift/centos-ruby-builder -s http://URL/scripts
```

alternatively, users can place their customized scripts into `.sti/` directory in the root of their GIT repository. The '-s' parameter takes precedense here.
